### PR TITLE
Patch with fix for demangle flag and output new line.

### DIFF
--- a/rtti-plugin-x64dbg/Lib/RTTI.cpp
+++ b/rtti-plugin-x64dbg/Lib/RTTI.cpp
@@ -13,13 +13,10 @@ using namespace std;
 string Demangle(char* sz_name)
 {
 	char tmp[MAX_CLASS_NAME] = { 0 };
-	if (UnDecorateSymbolName(sz_name, tmp, MAX_CLASS_NAME, UNDNAME_NAME_ONLY) == 0)
+	if (UnDecorateSymbolName(sz_name, tmp, MAX_CLASS_NAME, UNDNAME_NO_ARGUMENTS) == 0)
 		return false;
 
-	// Remove 'AV' from the name
-	char* n = tmp + 2;
-
-	return string(n);
+	return string(tmp);
 }
 
 duint GetBaseAddress(duint addr)

--- a/rtti-plugin-x64dbg/plugin.cpp
+++ b/rtti-plugin-x64dbg/plugin.cpp
@@ -81,7 +81,7 @@ static bool cbRttiCommand(int argc, char* argv[])
 			AutoLabel(rtti);
 			string rttiInfo = rtti.ToString();
 
-			dprintf(rttiInfo.c_str());
+			dprintf("%s\n", rttiInfo.c_str());
 		}
 		else
 			dprintf("No RTTI information found for address %p\n", addr);


### PR DESCRIPTION
Fixed Issue https://github.com/colinsenner/rtti-plugin-x64dbg/issues/1.
New output:
```
=====================================================================================
vftable: 00007FF7901CC188
  pCompleteObjectLocator: 00007FF78EE3E928
CompleteObjectLocator
  signature: 00000001 offset: 00000000 cdOffset: 00000000
  pTypeDescriptor: 06C06330
  pClassDescriptor: 0514E950
TypeDescriptor
  pTypeInfo: 00007FF78E07F400
  sz_decorated_name: ?AV?$_Ref_count_obj@VModel@CommonModel@@@std@@
ClassHierarchyDescriptor
  signature: 0 attributes: 0
  numBaseClasses: 2
  pBaseClassArray: 000000000514E968 (Offset from module base)

  class std::_Ref_count_base
    pTypeDescriptor: 0000000006651978 (Offset from module base)
    numContainedBases: 0
    mdisp: 0  pdisp: -1  vdisp: 0
    attributes: 40
class std::_Ref_count_obj<class CommonModel::Model>  :  class std::_Ref_count_base (+0) 
Invalid value: "HelloWorld"!
```
Old output:
```
=====================================================================================
vftable: 00007FF7901CC188
  pCompleteObjectLocator: 00007FF78EE3E928
CompleteObjectLocator
  signature: 00000001 offset: 00000000 cdOffset: 00000000
  pTypeDescriptor: 06C06330
  pClassDescriptor: 0514E950
TypeDescriptor
  pTypeInfo: 00007FF78E07F400
  sz_decorated_name: ?AV?$_Ref_count_obj@VModel@CommonModel@@@std@@
ClassHierarchyDescriptor
  signature: 0 attributes: 0
  numBaseClasses: 2
  pBaseClassArray: 000000000514E968 (Offset from module base)

  d::AV_Ref_count_base
    pTypeDescriptor: 0000000006651978 (Offset from module base)
    numContainedBases: 0
    mdisp: 0  pdisp: -1  vdisp: 0
    attributes: 40
V?$_Ref_count_obj@VModel@CommonModel@@@std@@  :  d::AV_Ref_count_base (+0) Invalid value: "HelloWorld"!
```