### PR TITLE
Remove dbghelp.dll dependency

### DIFF
--- a/rtti-plugin-x64dbg/Lib/RTTI.cpp
+++ b/rtti-plugin-x64dbg/Lib/RTTI.cpp
@@ -4,16 +4,17 @@
 #include "MemHelpers.h"
 #include "RTINFO.h"
 #include <string>
-#include <DbgHelp.h>
 
-#pragma comment(lib, "DbgHelp.lib")
+#define UNDNAME_TYPE_ONLY 0x2000
+
+extern "C" char *__cdecl __unDName(char *outputString, const char *name, int maxStringLength, void *pAlloc, void *pFree, unsigned short disableFlags);
 
 using namespace std;
 
 string Demangle(char* sz_name)
 {
 	char tmp[MAX_CLASS_NAME] = { 0 };
-	if (UnDecorateSymbolName(sz_name, tmp, MAX_CLASS_NAME, UNDNAME_NO_ARGUMENTS) == 0)
+	if (__unDName(tmp, sz_name, MAX_CLASS_NAME, malloc, free, UNDNAME_TYPE_ONLY) == 0)
 		return false;
 
 	return string(tmp);

--- a/rtti-plugin-x64dbg/Lib/RTTI.h
+++ b/rtti-plugin-x64dbg/Lib/RTTI.h
@@ -6,7 +6,6 @@
 
 using namespace std;
 
-#define MAX_CLASS_NAME 256
 #define MAX_BASE_CLASSES 12
 
 class RTTI {


### PR DESCRIPTION
The x64dbg also depends on the **dbghelp.dll** library and is distributed with an outdated version. The author says they are not going to update the library to the latest version: https://github.com/x64dbg/x64dbg/issues/3551#issuecomment-2770450930.
That version doesn't support an empty type parameter pack `$$V`. For example, `?AV?$_Func_base@E$$V@std@@` have to be demangled into `class std::_Func_base<unsigned char>`, but it fails now. To bypass this, the library has been replaced with **vcruntime140.dll**.